### PR TITLE
Allow for increment_proc to be an optional argument of multiple_apply.

### DIFF
--- a/hystorian/io/hyFile.py
+++ b/hystorian/io/hyFile.py
@@ -328,8 +328,7 @@ class HyFile:
                 f"process/{out_folder_location}/{name}", function, list_kwargs, first_kwarg=len(list_args)
             )
 
-    def multiple_apply(self, function, list_args, /, output_names=None, smart=False, **kwargs):
-        increment_proc = True
+    def multiple_apply(self, function, list_args, /, output_names=None, smart=False, increment_proc=True, **kwargs):
         if output_names is None:
             output_names = [arg.path.split("/")[-1] for arg in list_args]
 


### PR DESCRIPTION
Enables the multiple_apply not to increment the process number that is in place, for cases such as this one:

with HyFile('new_file.hdf5', 'r+') as f:
    f.multiple_apply(crop_data, f.path_search("data.*Amp"), output_names=chopchop(f.path_search("data.*Amp")),xstart=80, xend=150, ystart=185, yend=255)
    f.multiple_apply(crop_data, f.path_search("data.*Pha"), output_names=chopchop(f.path_search("data.*Pha")),xstart=80, xend=150, ystart=185, yend=255)
    f.multiple_apply(crop_data, f.path_search("data.*Fre"), output_names=chopchop(f.path_search("data.*Fre")),xstart=80, xend=150, ystart=185, yend=255)
    f.multiple_apply(crop_data, f.path_search("proc.*Adap.*ZSen"), output_names=chopchop(f.path_search("proc.*Adap.*ZSen")),xstart=80, xend=150, ystart=185, yend=255)